### PR TITLE
Removed ability to load a different driver

### DIFF
--- a/sqlalchemy_to_json_schema/command/main.py
+++ b/sqlalchemy_to_json_schema/command/main.py
@@ -4,13 +4,12 @@ from typing import Optional
 
 import click
 
+from sqlalchemy_to_json_schema.command.driver import Driver
 from sqlalchemy_to_json_schema.types import Decision, Format, Layout, Walker
-from sqlalchemy_to_json_schema.utils.imports import load_module_or_symbol
 
 DEFAULT_WALKER = Walker.STRUCTURAL
 DEFAULT_DECISION = Decision.DEFAULT
 DEFAULT_LAYOUT = Layout.SWAGGER_2
-DEFAULT_DRIVER = "sqlalchemy_to_json_schema.command.driver:Driver"
 
 
 @click.command()
@@ -31,7 +30,6 @@ DEFAULT_DRIVER = "sqlalchemy_to_json_schema.command.driver:Driver"
     default=DEFAULT_LAYOUT.value,
 )
 @click.option("--depth", type=int)
-@click.option("--driver", type=str, default=DEFAULT_DRIVER)
 @click.option(
     "--out",
     type=click.Path(
@@ -44,14 +42,12 @@ def main(
     walker: str,
     decision: str,
     layout: str,
-    driver: str,
     out: Optional[Path] = None,
     format: Optional[str] = None,
     depth: Optional[int] = None,
 ) -> None:
-    driver_cls = load_module_or_symbol(driver)
-    driver = driver_cls(Walker(walker), Decision(decision), Layout(layout))  # type: ignore[operator] # noqa: E501
-    driver.run(targets, filename=out, format=None if format is None else Format(format))  # type: ignore[attr-defined] # noqa: E501
+    driver = Driver(Walker(walker), Decision(decision), Layout(layout))
+    driver.run(targets, filename=out, format=None if format is None else Format(format))
 
 
 if __name__ == "__main__":

--- a/tests/command/test_main.py
+++ b/tests/command/test_main.py
@@ -8,7 +8,6 @@ from pytest_mock import MockerFixture
 
 from sqlalchemy_to_json_schema.command.main import (
     DEFAULT_DECISION,
-    DEFAULT_DRIVER,
     DEFAULT_LAYOUT,
     DEFAULT_WALKER,
     main,
@@ -18,22 +17,11 @@ from sqlalchemy_to_json_schema.types import Decision, Format, Layout, Walker
 
 @pytest.fixture
 def mock_driver(mocker: MockerFixture) -> Mock:
-    return mocker.patch("sqlalchemy_to_json_schema.command.driver.Driver", autospec=True)
-
-
-@pytest.fixture
-def mock_load_module_or_symbol(mock_driver: Mock, mocker: MockerFixture) -> Mock:
-    return mocker.patch(
-        "sqlalchemy_to_json_schema.command.main.load_module_or_symbol",
-        return_value=mock_driver,
-        autospec=True,
-    )
+    return mocker.patch("sqlalchemy_to_json_schema.command.main.Driver", autospec=True)
 
 
 @pytest.mark.parametrize("targets", [["my_module"]])
-def test_main_defaults(
-    mock_driver: Mock, mock_load_module_or_symbol: Mock, targets: Sequence[str]
-) -> None:
+def test_main_defaults(mock_driver: Mock, targets: Sequence[str]) -> None:
     """
     ARRANGE CLI args
     ACT calling the driver's method
@@ -49,8 +37,6 @@ def test_main_defaults(
     # ASSERT
     assert actual.exit_code == 0
 
-    mock_load_module_or_symbol.assert_called_once_with(DEFAULT_DRIVER)
-
     mock_driver.assert_called_once_with(DEFAULT_WALKER, DEFAULT_DECISION, DEFAULT_LAYOUT)
     mock_driver.return_value.run.assert_called_once_with(
         tuple(targets), filename=None, format=None
@@ -65,7 +51,6 @@ def test_main_defaults(
 @pytest.mark.parametrize("out", [Path("output.txt").absolute()])
 def test_main(
     mock_driver: Mock,
-    mock_load_module_or_symbol: Mock,
     targets: Sequence[str],
     walker: Walker,
     decision: Decision,
@@ -101,8 +86,6 @@ def test_main(
 
     # ASSERT
     assert actual.exit_code == 0
-
-    mock_load_module_or_symbol.assert_called_once_with(DEFAULT_DRIVER)
 
     mock_driver.assert_called_once_with(walker, decision, layout)
     mock_driver.return_value.run.assert_called_once_with(


### PR DESCRIPTION
This PR removes the ability to load alternative drivers in the sqlalchemy-to-json-schema library. By standardizing on a single default driver, the codebase becomes simpler and easier to maintain. This change reduces complexity and potential issues related to driver compatibility, ensuring more reliable and consistent behavior.