### PR TITLE
code cleanup

### DIFF
--- a/sqlalchemy_to_json_schema/command/main.py
+++ b/sqlalchemy_to_json_schema/command/main.py
@@ -1,15 +1,15 @@
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional
+from typing import Final, Optional
 
 import click
 
 from sqlalchemy_to_json_schema.command.driver import Driver
 from sqlalchemy_to_json_schema.types import Decision, Format, Layout, Walker
 
-DEFAULT_WALKER = Walker.STRUCTURAL
-DEFAULT_DECISION = Decision.DEFAULT
-DEFAULT_LAYOUT = Layout.SWAGGER_2
+DEFAULT_WALKER: Final = Walker.STRUCTURAL
+DEFAULT_DECISION: Final = Decision.DEFAULT
+DEFAULT_LAYOUT: Final = Layout.SWAGGER_2
 
 
 @click.command()

--- a/sqlalchemy_to_json_schema/command/transformer.py
+++ b/sqlalchemy_to_json_schema/command/transformer.py
@@ -119,16 +119,16 @@ class OpenAPI3Transformer(OpenAPI2Transformer):
     def transform(
         self, rawtargets: Iterable[Union[ModuleType, DeclarativeMeta]], depth: Optional[int], /
     ) -> Schema:
-        d = super().transform(rawtargets, depth)
+        definitions = super().transform(rawtargets, depth)
 
-        self.replace_ref(d, "#/definitions/", "#/components/schemas/")
+        self.replace_ref(definitions, "#/definitions/", "#/components/schemas/")
 
-        if "components" not in d:
-            d["components"] = {}
-        if "schemas" not in d["components"]:
-            d["components"]["schemas"] = {}
-        d["components"]["schemas"] = d.pop("definitions", {})
-        return d
+        if "components" not in definitions:
+            definitions["components"] = {}
+        if "schemas" not in definitions["components"]:
+            definitions["components"]["schemas"] = {}
+        definitions["components"]["schemas"] = definitions.pop("definitions", {})
+        return definitions
 
 
 def collect_models(module: ModuleType, /) -> Iterator[DeclarativeMeta]:

--- a/sqlalchemy_to_json_schema/schema_factory.py
+++ b/sqlalchemy_to_json_schema/schema_factory.py
@@ -320,7 +320,7 @@ class SchemaFactory:
             walker, schema, overrides=overrides_manager, depth=depth
         )
 
-        if overrides_manager is not None and overrides_manager.not_used_keys:
+        if overrides_manager.not_used_keys:
             raise InvalidStatus(f"invalid overrides: {overrides_manager.not_used_keys}")
 
         if model.__doc__:

--- a/sqlalchemy_to_json_schema/schema_factory.py
+++ b/sqlalchemy_to_json_schema/schema_factory.py
@@ -21,7 +21,7 @@ JSON Schema defines seven primitive types for JSON values:
 """
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional
 
 import sqlalchemy.types as t
 from sqlalchemy import Enum
@@ -173,12 +173,12 @@ DefaultClassfier = Classifier(default_column_to_schema)
 
 def get_children(
     name: str,
-    params: Optional[Union[Sequence[str], Mapping[str, Any]]],
+    params: Optional[Sequence[str]],
     /,
     *,
     splitter: str = ".",
-    default: Optional[Union[list[str], dict[str, Any]]] = None,
-) -> Union[list[str], dict[str, Any], None]:
+    default: Optional[list[str]] = None,
+) -> Optional[list[str]]:
     prefix = name + splitter
     if isinstance(params, dict):
         return {k.split(splitter, 1)[1]: v for k, v in params.items() if k.startswith(prefix)}
@@ -243,8 +243,6 @@ class ChildFactory:
         name = prop.key
         excludes = get_children(name, walker.includes, splitter=self.splitter, default=[])
         if not self.bidirectional:
-            if isinstance(excludes, dict):
-                raise RuntimeError(f"excludes is dict: {excludes}")
             if excludes is None:
                 raise RuntimeError("excludes is None")
             excludes.extend(self.default_excludes(prop))
@@ -253,8 +251,8 @@ class ChildFactory:
         return walker.clone(
             name,
             prop.mapper,
-            includes=includes,  # type: ignore[arg-type]
-            excludes=excludes,  # type: ignore[arg-type]
+            includes=includes,
+            excludes=excludes,
             history=history,
         )
 

--- a/sqlalchemy_to_json_schema/schema_factory.py
+++ b/sqlalchemy_to_json_schema/schema_factory.py
@@ -271,7 +271,7 @@ class ChildFactory:
         subschema = schema_factory._build_properties(
             walker,
             root_schema,
-            overrides=overrides,
+            overrides,
             depth=(depth and depth - 1),
             history=history,
             toplevel=False,
@@ -317,7 +317,7 @@ class SchemaFactory:
 
         schema: dict[str, Any] = {"title": model.__name__, "type": "object"}
         schema["properties"] = self._build_properties(
-            walker, schema, overrides=overrides_manager, depth=depth
+            walker, schema, overrides_manager, depth=depth
         )
 
         if overrides_manager.not_used_keys:
@@ -390,9 +390,9 @@ class SchemaFactory:
         self,
         walker: AbstractWalker,
         root_schema: Schema,
+        overrides: CollectionForOverrides,
         /,
         *,
-        overrides: Optional[CollectionForOverrides] = None,
         depth: Optional[int] = None,
         history: Optional[list[MapperProperty]] = None,
         toplevel: bool = True,

--- a/sqlalchemy_to_json_schema/schema_factory.py
+++ b/sqlalchemy_to_json_schema/schema_factory.py
@@ -20,8 +20,10 @@ JSON Schema defines seven primitive types for JSON values:
         A JSON string.
 """
 
+from __future__ import annotations
+
 from collections.abc import Mapping, Sequence
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import sqlalchemy.types as t
 from sqlalchemy import Enum
@@ -142,7 +144,7 @@ def get_class_mapping(
     *,
     see_mro: bool = True,
     see_impl: bool = True,
-) -> tuple[Optional[DeclarativeMeta], Optional[TypeFormatFn]]:
+) -> tuple[DeclarativeMeta | None, TypeFormatFn | None]:
     v = mapping.get(cls)
     if v is not None:
         return cls, v  # type: ignore[return-value]
@@ -173,12 +175,12 @@ DefaultClassfier = Classifier(default_column_to_schema)
 
 def get_children(
     name: str,
-    params: Optional[Sequence[str]],
+    params: Sequence[str] | None,
     /,
     *,
     splitter: str = ".",
-    default: Optional[list[str]] = None,
-) -> Optional[list[str]]:
+    default: list[str] | None = None,
+) -> list[str] | None:
     prefix = name + splitter
     if isinstance(params, dict):
         return {k.split(splitter, 1)[1]: v for k, v in params.items() if k.startswith(prefix)}
@@ -238,7 +240,7 @@ class ChildFactory:
         walker: AbstractWalker,
         /,
         *,
-        history: Optional[Any] = None,
+        history: Any | None = None,
     ) -> AbstractWalker:
         name = prop.key
         excludes = get_children(name, walker.includes, splitter=self.splitter, default=[])
@@ -259,14 +261,14 @@ class ChildFactory:
     def child_schema(
         self,
         prop: MapperProperty,
-        schema_factory: Any,
-        root_schema: Mapping[str, Any],
+        schema_factory: SchemaFactory,
+        root_schema: dict[str, Any],
         walker: AbstractWalker,
         overrides: Any,
         /,
         *,
-        depth: Optional[int] = None,
-        history: Optional[Any] = None,
+        depth: int | None = None,
+        history: Any | None = None,
     ) -> dict[str, Any]:
         subschema = schema_factory._build_properties(
             walker,
@@ -290,8 +292,8 @@ class SchemaFactory:
         *,
         classifier: Classifier = DefaultClassfier,
         restriction_dict: RestrictionDict = default_restriction_dict,
-        child_factory: Optional[ChildFactory] = None,
-        relation_decision: Optional[AbstractDecision] = None,
+        child_factory: ChildFactory | None = None,
+        relation_decision: AbstractDecision | None = None,
     ) -> None:
         self.classifier = classifier
         self.walker = walker  # class
@@ -306,11 +308,11 @@ class SchemaFactory:
         model: DeclarativeMeta,
         /,
         *,
-        includes: Optional[Sequence[str]] = None,
-        excludes: Optional[Sequence[str]] = None,
-        overrides: Optional[dict] = None,
-        depth: Optional[int] = None,
-        adjust_required: Optional[Callable[[MapperProperty, bool], bool]] = None,
+        includes: Sequence[str] | None = None,
+        excludes: Sequence[str] | None = None,
+        overrides: dict | None = None,
+        depth: int | None = None,
+        adjust_required: Callable[[MapperProperty, bool], bool] | None = None,
     ) -> Schema:
         walker = self.walker(model, includes=includes, excludes=excludes)
         overrides_manager = CollectionForOverrides(overrides or {})
@@ -393,8 +395,8 @@ class SchemaFactory:
         overrides: CollectionForOverrides,
         /,
         *,
-        depth: Optional[int] = None,
-        history: Optional[list[MapperProperty]] = None,
+        depth: int | None = None,
+        history: list[MapperProperty] | None = None,
         toplevel: bool = True,
     ) -> dict[str, Any]:
         definitions: dict[str, Any] = {}
@@ -462,7 +464,7 @@ class SchemaFactory:
         walker: AbstractWalker,
         /,
         *,
-        adjust_required: Optional[Callable[[MapperProperty, bool], bool]] = None,
+        adjust_required: Callable[[MapperProperty, bool], bool] | None = None,
     ) -> list[str]:
         required_properties_set = set()
 

--- a/sqlalchemy_to_json_schema/schema_factory.py
+++ b/sqlalchemy_to_json_schema/schema_factory.py
@@ -180,9 +180,7 @@ def get_children(
     default: Optional[Union[list[str], dict[str, Any]]] = None,
 ) -> Union[list[str], dict[str, Any], None]:
     prefix = name + splitter
-    if hasattr(params, "items"):
-        if params is None:
-            raise RuntimeError("params is None")
+    if isinstance(params, dict):
         return {k.split(splitter, 1)[1]: v for k, v in params.items() if k.startswith(prefix)}
     elif isinstance(params, (list, tuple)):
         return [e.split(splitter, 1)[1] for e in params if e.startswith(prefix)]

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import sqlalchemy as sa
 import sqlalchemy.orm as orm
+from pytest_unordered import unordered
 from sqlalchemy.orm import Mapped, declarative_base
 
 from sqlalchemy_to_json_schema.decisions import UseForeignKeyIfPossibleDecision
@@ -60,7 +61,7 @@ def test_properties__default__includes__foreign_keys() -> None:
     result = target(User)
 
     assert "properties" in result
-    assert list(sorted(result["properties"].keys())) == ["group_id", "name", "pk"]
+    assert list(result["properties"].keys()) == unordered(["group_id", "name", "pk"])
 
 
 def test_properties__include_OnetoMany_relation() -> None:
@@ -68,7 +69,7 @@ def test_properties__include_OnetoMany_relation() -> None:
     result = target(User)
 
     assert "required" in result
-    assert list(sorted(result["properties"])) == ["group", "name", "pk"]
+    assert list(result["properties"]) == unordered(["group", "name", "pk"])
     assert result["properties"]["group"] == {"$ref": "#/definitions/Group"}
 
 
@@ -77,7 +78,7 @@ def test_properties__include_OnetoMany_relation2() -> None:
     result = target(User)
 
     assert "required" in result
-    assert list(sorted(result["properties"])) == ["group_id", "name", "pk"]
+    assert list(result["properties"]) == unordered(["group_id", "name", "pk"])
     assert result["properties"]["group_id"] == {"type": "integer", "relation": "group"}
 
 
@@ -86,7 +87,7 @@ def test_properties__include_ManytoOne_backref() -> None:
     result = target(Group)
 
     assert "required" in result
-    assert list(sorted(result["properties"])) == ["name", "pk", "users"]
+    assert list(result["properties"]) == unordered(["name", "pk", "users"])
     assert result["properties"]["users"] == {
         "type": "array",
         "items": {"$ref": "#/definitions/User"},
@@ -174,7 +175,7 @@ def test_properties__default_depth_is__traverse_all_chlidren() -> None:
     result = target(A0)
 
     assert "required" in result
-    assert list(sorted(result["properties"])) == ["children", "pk"]
+    assert list(result["properties"]) == unordered(["children", "pk"])
     children0 = get_reference(result["properties"]["children"]["items"], result)
     children1 = get_reference(children0["properties"]["children"]["items"], result)
     children2 = get_reference(children1["properties"]["children"]["items"], result)
@@ -188,7 +189,7 @@ def test_properties__default_depth_is__2__traverse_depth2() -> None:
     result = target(A0, depth=2)
 
     assert "required" in result
-    assert list(sorted(result["properties"])) == ["children", "pk"]
+    assert list(result["properties"]) == unordered(["children", "pk"])
     children0 = get_reference(result["properties"]["children"]["items"], result)
     assert children0["properties"]["pk"]["description"] == "primary key1"
 
@@ -198,7 +199,7 @@ def test_properties__default_depth_is__3__traverse_depth3() -> None:
     result = target(A0, depth=3)
 
     assert "required" in result
-    assert list(sorted(result["properties"])) == ["children", "pk"]
+    assert list(result["properties"]) == unordered(["children", "pk"])
     children0 = get_reference(result["properties"]["children"]["items"], result)
     children1 = get_reference(children0["properties"]["children"]["items"], result)
     assert children1["properties"]["pk"]["description"] == "primary key2"
@@ -236,7 +237,7 @@ def test_properties__infinite_loop() -> None:
     zs = get_reference(ys, result)["properties"]["zs"]
     xs = get_reference(zs, result)["properties"]
     assert "required" in result
-    assert list(sorted(result["properties"])) == ["id", "ys"]
+    assert list(result["properties"]) == unordered(["id", "ys"])
     assert xs["id"]["description"] == "primary key"
 
 
@@ -244,6 +245,6 @@ def test_properties__infinite_loop2() -> None:
     target = _makeOne(StructuralWalker, relation_decision=UseForeignKeyIfPossibleDecision())
     result = target(X)
     assert "required" in result
-    assert list(sorted(result["properties"])) == ["id", "y_id"]
+    assert list(result["properties"]) == unordered(["id", "y_id"])
 
     assert result["properties"]["y_id"] == {"type": "integer", "relation": "ys"}

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlalchemy as sa
 import sqlalchemy.orm as orm
+from pytest_unordered import unordered
 from sqlalchemy.orm import declarative_base
 
 from sqlalchemy_to_json_schema.exceptions import InvalidStatus
@@ -47,7 +48,7 @@ def test_properties__are__all_of_columns() -> None:
     result = target(Group)
 
     assert "properties" in result
-    assert list(sorted(result["properties"].keys())) == ["color", "name", "pk"]
+    assert list(result["properties"].keys()) == unordered(["color", "name", "pk"])
 
 
 def test_title__id__model_class_name() -> None:
@@ -87,13 +88,13 @@ def test_properties__all__this_is_slackoff_little_bit__all_is_all() -> None:  # 
 def test__filtering_by__includes() -> None:
     target = _makeOne()
     result = target(Group, includes=["pk"])
-    assert list(sorted(result["properties"].keys())) == ["pk"]
+    assert list(result["properties"].keys()) == unordered(["pk"])
 
 
 def test__filtering_by__excludes() -> None:
     target = _makeOne()
     result = target(Group, excludes=["pk"])
-    assert list(sorted(result["properties"].keys())) == ["color", "name"]
+    assert list(result["properties"].keys()) == unordered(["color", "name"])
 
 
 def test__filtering_by__excludes_and_includes__conflict() -> None:


### PR DESCRIPTION
- Removed unreachable code
- Simplified types in `get_children()`
- Simplified if statement
- Use unordered instead of sorting in tests
- Non-nullable overrides
- Renamed variable
- Fixed type annotations
